### PR TITLE
Delete created group on callflow error

### DIFF
--- a/submodules/groups/groups.js
+++ b/submodules/groups/groups.js
@@ -1691,6 +1691,19 @@ define(function(require){
 						success: function(data) {
 							callback && callback(dataGroup.data);
 						}
+						error: function(e) {
+							monster.request({
+								resource: 'voip.groups.deleteGroup',
+								data: {
+									accountId: self.accountId,
+									groupId: dataGroup.data.id,
+									data: {}
+								},
+								success: function() {
+									
+								}
+							});
+						}
 					});
 				}
 			});


### PR DESCRIPTION
When adding groups and the callflow number exists the group is still added but has no extension number. 

This deletes the created group if an error occurs when creating callflow.
