### PR TITLE
fix - typo that prevents display/edit sip device

### DIFF
--- a/views/devices-sip_device.html
+++ b/views/devices-sip_device.html
@@ -2,7 +2,7 @@
 	<div class="title-bar clearfix">
 		<div class="device-title pull-left">
 			{{#if provision}}
-			<div class="device-image model-image {{toLowerCase provision.endpoint_brand}}-{{toLowerCase provisioner.endpoint_family}}-{{toLowerCase provision.endpoint_model}}"></div>
+			<div class="device-image model-image {{toLowerCase provision.endpoint_brand}}-{{toLowerCase provision.endpoint_family}}-{{toLowerCase provision.endpoint_model}}"></div>
 			<div class="device-model">{{provision.endpoint_brand}} - {{provision.endpoint_model}}</div>
 			{{else}}
 				<div class="device-icon">


### PR DESCRIPTION
this typo used with toLowerCase causes an exception and prevents the popup dialog to show