### PR TITLE
UI-1840: Correct module name typo in the MainFaxing callflow

### DIFF
--- a/submodules/strategy/strategy.js
+++ b/submodules/strategy/strategy.js
@@ -2337,7 +2337,7 @@ define(function(require){
 										flow: {
 											children: {},
 											data: {},
-											module: "faxing"
+											module: "faxbox"
 										}
 									}
 								},


### PR DESCRIPTION
Fixes the MainFaxig callflow module name. It should be "faxbox" instead of "faxing".