### PR TITLE
UI-2562: Fix CSS selector to populate key value

### DIFF
--- a/submodules/devices/devices.js
+++ b/submodules/devices/devices.js
@@ -324,7 +324,7 @@ define(function(require){
 						templateDevice
 							.find(section.concat(group, value))
 								.addClass('active')
-							.find('[name="provision.feature_keys[' + key + '].value"]')
+							.find('[name="provision.keys.' + value.id + '[' + key + '].value"]')
 								.val(val.value);
 					});
 				});


### PR DESCRIPTION
It was missing the .key class and was only populating feature keys due to hard coded class (.feature_keys)