### PR TITLE
Add distinctive ring feature to groups

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -102,6 +102,12 @@
 			"__version": "4.1",
 			"devices": "Devices"
 		},
+		"distinctiveRing": {
+			"title":"Distinctive Ring",
+			"headline": "Distinctive Ring",
+			"externalRingtones": "External ringtones",
+			"internalRingtones": "Internal ringtones"
+		},
 		"__comment": "UI-819, v3.19_s1: Showing an error popup when group data is outdated.",
 		"outdatedGroupsError": "Your Group's data is outdated and can not be rendered. Please contact your administrator to update your data.",
 
@@ -137,7 +143,6 @@
 		"__version": "3.22",
 		"emptyEndpointsWarning": "You need to select at least one member to create a group"
 	},
-
 	"devices": {
 		"add": "Add Device",
 		"assigned": "Assigned",

--- a/views/groups-feature-distinctive-ring.html
+++ b/views/groups-feature-distinctive-ring.html
@@ -1,0 +1,27 @@
+<div class="monster-feature-popup-container" data-feature="distinctive_ring">
+	<div class="feature-popup-title">
+		<div class="feature-fa-wrapper">
+			<i class="{{group.extra.mapFeatures.distinctive_ring.icon}}"></i>
+		</div>
+		{{ i18n.groups.distinctiveRing.headline}}
+	</div>
+	<div class="content">
+		<form id="distinctive_ring_form">
+			<div>
+				<span>{{ i18n.groups.distinctiveRing.externalRingtones }}</span>
+				<input name="external" id="distinctive-ring-external" type="text" value="{{external}}">
+			</div>
+			<div>
+				<span>{{ i18n.groups.distinctiveRing.internalRingtones }}</span>
+				<input required name="internal" id="distinctive-ring-internal" type="text" value="{{internal}}">
+			</div>
+		</form>
+	</div>
+	<div class="actions clearfix">
+		<div class="pull-right">
+			<a class="cancel-link monster-link blue" href="javascript:void(0);">{{ i18n.cancel }}</a>
+			<button type="button" class="monster-button monster-button-success save">{{ i18n.saveChanges }}
+			</button>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
This exposes the kazoo feature of [using distinctive ring on groups](https://github.com/2600hz/kazoo/commit/36e8e15f586879f37e69c40140245950e84f1e3e). This allows users in a group to have different ring tones set for when they are receiving calls externally or internally. 