### PR TITLE
Add option to hide checkbox for sending new user credentials

### DIFF
--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -1696,6 +1696,8 @@ define(function(require) {
 			allNumbers = arrayExtensions.concat(arrayVMBoxes);
 			formattedData.nextExtension = parseInt(monster.util.getNextExtension(allNumbers)) + '';
 
+			formattedData.showSendEmailOnCreation = monster.config.whitelabel && monster.config.whitelabel.showSendUserEmailOnCreation ? true : false;
+
 			return formattedData;
 		},
 
@@ -3257,6 +3259,7 @@ define(function(require) {
 						},
 						presence_id: data.callflow.extension,
 						email: data.extra.differentEmail ? data.extra.email : data.user.username,
+						send_email_on_creation: data.send_email_on_creation || false,
 						priv_level: 'user'
 					}, data.user),
 					vmbox: {

--- a/views/users-creation.html
+++ b/views/users-creation.html
@@ -73,6 +73,7 @@
 				<input type="email" name="extra.email" id="email" placeholder="{{i18n.users.dialogCreationUser.notificationEmail}}">
 			</div>
 		</div>
+		{{#if showSendEmailOnCreation}}
 		<div class="control-group hack-left">
 			<label class="control-label" for="send_email_on_creation"></label>
 			<div class="controls">
@@ -81,6 +82,7 @@
 				{{/monsterCheckbox}}
 			</div>
 		</div>
+		{{/if}}
 	</div>
 	</form>
 	<div class="dialog-buttons-wrapper">


### PR DESCRIPTION
Depending on the monster config, this checkbox can now be hidden from the user in the user creation dialog. Users and admins might not want credentials to be sent in plain text over email because of security concerns.