### PR TITLE
Toggle user caller id strategy

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -671,6 +671,8 @@
 		"caller_id": {
 			"title": "Caller-ID Number",
 			"dropdownLabel": "Show my Caller-Id Number as",
+			"currentCallerIdLabel": "Current Caller-ID: ",
+			"none": "None",
 			"headline": "User Caller-ID Number Settings",
 			"help": "If you don't enable this feature, the Caller-ID displayed by default will be the one configured on the Main Number of this account."
 		},

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -1375,11 +1375,11 @@ define(function(require) {
 							phoneNumber;
 						for (phoneNumber in numberChoices) {
 							numberChoices[monster.util.formatPhoneNumber(phoneNumber)] = $.extend(true, {}, numberChoices[phoneNumber]);
-							if(phoneNumber !== monster.util.formatPhoneNumber(phoneNumber)) {
+							if (phoneNumber !== monster.util.formatPhoneNumber(phoneNumber)) {
 								delete numberChoices[phoneNumber];
 							}
 						}
-						if(currentUser.caller_id && currentUser.caller_id.external && currentUser.caller_id.external.number) {
+						if (currentUser.caller_id && currentUser.caller_id.external && currentUser.caller_id.external.number) {
 							currentUser.caller_id.external.number = monster.util.formatPhoneNumber(currentUser.caller_id.external.number);
 						}
 						self.usersRenderCallerId(currentUser, numberChoices);
@@ -2067,7 +2067,7 @@ define(function(require) {
 				});
 			});
 
-			if(currentUser.extra.listCallerId.length > 0 || monster.config.whitelabel && monster.config.whitelabel.allowAnyOwnedNumberAsCallerID) {
+			if (currentUser.extra.listCallerId.length > 0 || monster.config.whitelabel && monster.config.whitelabel.allowAnyOwnedNumberAsCallerID) {
 				var popup = monster.ui.dialog(featureTemplate, {
 					title: currentUser.extra.mapFeatures.caller_id.title,
 					position: ['center', 20]

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -1369,7 +1369,24 @@ define(function(require) {
 			});
 
 			template.on('click', '.feature[data-feature="caller_id"]', function() {
-				self.usersRenderCallerId(currentUser);
+				if (monster.config.whitelabel && monster.config.whitelabel.allowAnyOwnedNumberAsCallerID) {
+					self.usersListNumbers(function(accountNumbers) {
+						var numberChoices = accountNumbers.numbers,
+							phoneNumber;
+						for (phoneNumber in numberChoices) {
+							numberChoices[monster.util.formatPhoneNumber(phoneNumber)] = $.extend(true, {}, numberChoices[phoneNumber]);
+							if(phoneNumber !== monster.util.formatPhoneNumber(phoneNumber)) {
+								delete numberChoices[phoneNumber];
+							}
+						}
+						if(currentUser.caller_id && currentUser.caller_id.external && currentUser.caller_id.external.number) {
+							currentUser.caller_id.external.number = monster.util.formatPhoneNumber(currentUser.caller_id.external.number);
+						}
+						self.usersRenderCallerId(currentUser, numberChoices);
+					});
+				} else {
+					self.usersRenderCallerId(currentUser);
+				}
 			});
 
 			template.on('click', '.feature[data-feature="call_forward"]', function() {
@@ -1999,10 +2016,19 @@ define(function(require) {
 			});
 		},
 
-		usersRenderCallerId: function(currentUser) {
+		usersRenderCallerId: function(currentUser, numberChoices) {
 			var self = this,
-				featureTemplate = $(monster.template(self, 'users-feature-caller_id', currentUser)),
-				switchFeature = featureTemplate.find('.switch-state');
+				allowAnyOwnedNumberAsCallerID = monster.config.whitelabel && monster.config.whitelabel.allowAnyOwnedNumberAsCallerID ? true : false,
+				templateUser = $.extend(true, {allowAnyOwnedNumberAsCallerID: allowAnyOwnedNumberAsCallerID}, currentUser),
+				featureTemplate,
+				switchFeature;
+
+			if (numberChoices && monster.config.whitelabel && monster.config.whitelabel.allowAnyOwnedNumberAsCallerID) {
+				templateUser.caller_id.numberChoices = numberChoices;
+			}
+
+			featureTemplate = $(monster.template(self, 'users-feature-caller_id', templateUser));
+			switchFeature = featureTemplate.find('.switch-state');
 
 			featureTemplate.find('.cancel-link').on('click', function() {
 				popup.dialog('close').remove();
@@ -2041,7 +2067,7 @@ define(function(require) {
 				});
 			});
 
-			if (currentUser.extra.listCallerId.length > 0) {
+			if(currentUser.extra.listCallerId.length > 0 || monster.config.whitelabel && monster.config.whitelabel.allowAnyOwnedNumberAsCallerID) {
 				var popup = monster.ui.dialog(featureTemplate, {
 					title: currentUser.extra.mapFeatures.caller_id.title,
 					position: ['center', 20]

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -2067,7 +2067,7 @@ define(function(require) {
 				});
 			});
 
-			if (currentUser.extra.listCallerId.length > 0 || monster.config.whitelabel && monster.config.whitelabel.allowAnyOwnedNumberAsCallerID) {
+			if (currentUser.extra.listCallerId.length > 0 || (monster.config.whitelabel && monster.config.whitelabel.allowAnyOwnedNumberAsCallerID)) {
 				var popup = monster.ui.dialog(featureTemplate, {
 					title: currentUser.extra.mapFeatures.caller_id.title,
 					position: ['center', 20]

--- a/views/users-feature-caller_id.html
+++ b/views/users-feature-caller_id.html
@@ -11,11 +11,21 @@
 		</div>
 	</div>
 	<div class="content{{#unless extra.mapFeatures.caller_id.active}} disabled{{/unless}}">
+		{{#if allowAnyOwnedNumberAsCallerID }}
+			{{ i18n.users.caller_id.currentCallerIdLabel }}
+			{{#if caller_id.external.number }}{{ caller_id.external.number }}{{else}}{{i18n.users.caller_id.none}}{{/if}}<br />
+		{{/if}}
 		{{ i18n.users.caller_id.dropdownLabel }}
 		<select class="caller-id-select">
-			{{#each extra.listCallerId}}
-				<option{{#compare ../this.caller_id.external.number "===" this}} selected{{/compare}} value="{{this}}">{{this}}</option>
-			{{/each}}
+			{{#if allowAnyOwnedNumberAsCallerID }}
+				{{#each caller_id.numberChoices}}
+					<option{{#compare ../caller_id.external.number "===" @key}} selected{{/compare}} value="{{@key}}">{{@key}}</option>
+				{{/each}}
+			{{else}}
+				{{#each extra.listCallerId}}
+					<option{{#compare ../this.caller_id.external.number "===" this}} selected{{/compare}} value="{{this}}">{{this}}</option>
+				{{/each}}
+			{{/if}}
 		</select>
 
 		{{#monsterText}}


### PR DESCRIPTION
Toggling a new config setting allows choice between two different ways a user can set a user's caller ID. It can either be the standard way (only able to choose numbers assigned to the user, otherwise main number is used) or being able to choose any number belonging to the account.