### PR TITLE
UI-3019: Fix dashboard 50 user count and PDF directory limit

### DIFF
--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -379,7 +379,10 @@ define(function(require) {
 									resource: 'directory.get',
 									data: {
 										accountId: self.accountId,
-										directoryId: mainDirectory.id
+										directoryId: mainDirectory.id,
+										filters: {
+											paginate: false
+										}
 									},
 									success: function(data, status) {
 										parallelCallback && parallelCallback(null, data.data);
@@ -655,7 +658,7 @@ define(function(require) {
 			data.unregisteredDevices = unregisteredDevices;
 
 			if (data.directory && data.directory.id) {
-				data.directoryLink = self.apiUrl + 'accounts/' + self.accountId + '/directories/' + data.directory.id + '?accept=pdf&auth_token=' + self.getAuthToken();
+				data.directoryLink = self.apiUrl + 'accounts/' + self.accountId + '/directories/' + data.directory.id + '?accept=pdf&paginate=false&auth_token=' + self.getAuthToken();
 			}
 
 			return data;


### PR DESCRIPTION
This removes the default pagination limit of the SmartPBX directory grab, which limited the directory user count to 50 or less and also limited the PDF download to only include 50 or less users.