### PR TITLE
Call Forward Activate pattern

### DIFF
--- a/submodules/strategy/strategy.js
+++ b/submodules/strategy/strategy.js
@@ -53,7 +53,7 @@ define(function(require) {
 			{
 				name: 'call_forward[action=activate]',
 				number: '72',
-				callflowNumber: '*72',
+				pattern: '\\*72([0-9]*)$',
 				moduleName: 'call_forward',
 				actionName: 'activate'
 			},


### PR DESCRIPTION
Change the Call Forward Activate strategy feature code to be a pattern.

This makes it easier to use native IP phone settings to set call forward number, without having to go through the voice prompt.