### PR TITLE
UI-3053: Added Smart PBX SIP Device feature key drag and drop reordering

### DIFF
--- a/submodules/devices/devices.css
+++ b/submodules/devices/devices.css
@@ -62,8 +62,8 @@
 	color: #22a5ff;
 }
 
-#devices_container .devices-header .search-box { 
-	margin: 16px 0 16px 15px; 
+#devices_container .devices-header .search-box {
+	margin: 16px 0 16px 15px;
 }
 
 #devices_container .devices-grid {
@@ -384,6 +384,12 @@
 .voip-edit-device-popup .edit-device .feature-key-value label {
 	display: inline-block;
 	margin-right: 10px;
+}
+
+.voip-edit-device-popup .keys .fa {
+	display: inline-block;
+	padding-right: 15px;
+	cursor: move;
 }
 
 /* Codecs selector */

--- a/submodules/devices/devices.js
+++ b/submodules/devices/devices.js
@@ -337,6 +337,20 @@ define(function(require) {
 					});
 				});
 
+				$(function() {
+					templateDevice.find('.keys').sortable({
+						items: '.control-group',
+						update: function() {
+							templateDevice
+								.find('.feature-key-index')
+									.each(function(idx, el) {
+										$(el).text(idx + 1);
+									});
+						}
+					});
+					templateDevice.find('.keys').disableSelection();
+				});
+
 				templateDevice
 					.find('.feature-key-index')
 						.each(function(idx, el) {

--- a/submodules/devices/devices.js
+++ b/submodules/devices/devices.js
@@ -337,18 +337,15 @@ define(function(require) {
 					});
 				});
 
-				$(function() {
-					templateDevice.find('.keys').sortable({
-						items: '.control-group',
-						update: function() {
-							templateDevice
+				templateDevice.find('.keys').sortable({
+					items: '.control-group',
+					update: function() {
+						templateDevice
 								.find('.feature-key-index')
 									.each(function(idx, el) {
 										$(el).text(idx + 1);
 									});
-						}
-					});
-					templateDevice.find('.keys').disableSelection();
+					}
 				});
 
 				templateDevice

--- a/views/devices-sip_device.html
+++ b/views/devices-sip_device.html
@@ -306,6 +306,7 @@
 						{{/compare}}
 					{{/compare}}
 					<label for="provision.keys.{{../id}}[{{@key}}].type" class="control-label">
+						<i class="fa fa-reorder monster-gray"></i>
 						{{ ../label }} <span class="feature-key-index">{{@key}}</span>
 					</label>
 					<div class="controls">


### PR DESCRIPTION
UI-3053 - This addition allows for reordering of feature keys while editing a device from Smart PBX.  This utilizes JQuery sortable and resaves the data in the specified order when saving. 