### PR TITLE
UI-3096: Only list groups created with SmartPBX

### DIFF
--- a/submodules/groups/groups.js
+++ b/submodules/groups/groups.js
@@ -118,7 +118,8 @@ define(function(require) {
 			});
 
 			_.each(mapGroups, function(group) {
-				arrayGroups.push(group);
+				// Only list groups created with SmartPBX (e.g. with an associated baseGroup callflow)
+				group.extra.hasOwnProperty('baseCallflowId') && arrayGroups.push(group);
 			});
 
 			arrayGroups.sort(function(a, b) {


### PR DESCRIPTION
When creating groups on SmartPBX, the app automatically generates
baseGroup/userGroup callflows depending on which users are part of the
group. On the other end, the Callflows app only creates a group without
any callflow.
Since SmartPBX is listing all groups, an error was raised when trying to
view the details of group created through the Callflows app since an
associated callflow does not exist.