### PR TITLE
 UI-3140: Lunch hours time of day object will only be valid on days the business is open

### DIFF
--- a/submodules/strategy/strategy.js
+++ b/submodules/strategy/strategy.js
@@ -1630,6 +1630,18 @@ define(function(require) {
 
 						if (customHours.lunchbreak.enabled) {
 							var lunchbreakRule = strategyData.temporalRules.lunchbreak;
+
+							// make sure the lunch rule is only valid on days the business is open
+							delete lunchbreakRule.wdays;							
+							var lunchwdays = [];							
+							_.each(customHours.opendays, function(val) {
+								lunchwdays.push(val.substring(4).toLowerCase());
+							});
+														
+							lunchbreakRule = $.extend(true, {
+								wdays: lunchwdays
+							}, lunchbreakRule);
+
 							lunchbreakRule.time_window_start = monster.util.timeToSeconds(customHours.lunchbreak.from);
 							lunchbreakRule.time_window_stop = monster.util.timeToSeconds(customHours.lunchbreak.to);
 							tmpRulesRequests.lunchbreak = function(callback) {


### PR DESCRIPTION
As per issue UI-3140, currenly the time of day object for lunch hours contains all weekdays by default. This needs to reflect the days the business is open. On days the business is closed, the lunch hours time of day object should not be valid.