### PR TITLE
UI-3286: Set default option on select main extension pop-up

### DIFF
--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -1952,7 +1952,7 @@ define(function(require) {
 					return number === formattedPresenceID;
 				});
 			} else {
-				return !listNumbers.length;
+				return _.isEmpty(listNumbers);
 			}
 		},
 

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -1946,20 +1946,13 @@ define(function(require) {
 			var self = this;
 
 			if (user.presence_id) {
-				var found = false,
-					formattedPresenceID = '' + user.presence_id;
+				var formattedPresenceID = '' + user.presence_id;
 
-				_.each(listNumbers, function(number) {
-					if (number === formattedPresenceID) {
-						found = true;
-					}
+				return _.some(listNumbers, function(number) {
+					return number === formattedPresenceID;
 				});
-
-				return found;
-			} else if (listNumbers.length) {
-				return false;
 			} else {
-				return true;
+				return !listNumbers.length;
 			}
 		},
 

--- a/submodules/users/views/changePresenceIDPopup.html
+++ b/submodules/users/views/changePresenceIDPopup.html
@@ -4,10 +4,10 @@
 	</div>
 
 	<div class="list-choices">
-		{{#each numbers}} 
-			<div class="presence-id-option" data-number="{{this}}">{{ formatPhoneNumber this }}</div>
+		{{#each numbers}}
+			<div class="presence-id-option{{#if @first}} active{{/if}}" data-number="{{this}}">{{ formatPhoneNumber this }}</div>
 		{{/each}}
-		<div class="presence-id-option" data-number="none"> 
+		<div class="presence-id-option{{#unless numbers.length}} active{{/unless}}" data-number="none">
 			{{ i18n.users.presenceIDPopup.none}}
 		</div>
 	</div>


### PR DESCRIPTION
To prevent a user from saving the changes without selecting any valid option, thus setting 'null' as a value for the user's `presence_id`.