### PR TITLE
UI-3328: Reverse module presence check to compare against skipped_modules

### DIFF
--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -324,7 +324,7 @@ define(function(require) {
 				}
 
 				// Check if user has vmbox enabled
-				if (_.includes(_mainCallflow.modules, 'voicemail')) {
+				if (!_.includes(_mainCallflow.skipped_modules, 'voicemail')) {
 					dataUser.extra.features.push('vmbox');
 				}
 			}


### PR DESCRIPTION
Had to merge #132 as it was fixing a somewhat critical bug (the fact that voicemail box indicators do not appear properly was factored in).

As you can see, the property to check against is now `skipped_modules` so I just wanted to see if you could think of any side effects following this change since you are the feature owner.