### PR TITLE
MSPB-4: Allow devices to be restarted from user page

### DIFF
--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -1240,11 +1240,13 @@ define(function(require) {
 			template.on('click', '.detail-devices .edit-device-link', function() {
 				var row = $(this).parents('.item-row'),
 					id = row.data('id'),
-					userId = $(this).parents('.grid-row').data('id');
+					userId = $(this).parents('.grid-row').data('id'),
+					userData = _.find(data.users, function(user) { return user.id === userId; }),
+					deviceData = _.find(userData.extra.devices, function(device) { return device.id === id; });
 
 				monster.pub('voip.devices.editDevice', {
 					allowAssign: false,
-					data: { id: id },
+					data: { id: id, isRegistered: deviceData.registered },
 					callbackSave: function(device) {
 						row.find('.edit-device').html(device.name);
 					},

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -1241,8 +1241,8 @@ define(function(require) {
 				var row = $(this).parents('.item-row'),
 					id = row.data('id'),
 					userId = $(this).parents('.grid-row').data('id'),
-					userData = _.find(data.users, function(user) { return user.id === userId; }),
-					deviceData = _.find(userData.extra.devices, function(device) { return device.id === id; });
+					userData = _.find(data.users, { id: userId }),
+					deviceData = _.find(userData.extra.devices, { id: id });
 
 				monster.pub('voip.devices.editDevice', {
 					allowAssign: false,


### PR DESCRIPTION
The "Restart" button is grayed out when accessed via the “User” page, but is available via “Device” page within the 2600/Kazoo stack.

Steps to Reproduce:
- Log in
- Navigate to the Smart PBX app
- Navigate to the Users panel
- Chose a user with a working desktop phone
- Click on the desktop phone icon
- Click on the name of the device
- Chose the Advanced option
- Chose Miscellaneous 

Actual Results: The Restart phone button is grayed out

Expected Results: The Restart phone button should not be grayed out. 

This pull request fixes this issue, allowing devices to be restarted from the User page.