### PR TITLE
MSPB-8: Refactor dashboard data formatter

### DIFF
--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -516,7 +516,6 @@ define(function(require) {
 				// 		color: '#b588b9'
 				// 	}
 				// },
-				channelsArray = [],
 				classifierRegexes = {},
 				classifiedNumbers = {},
 				registeredDevices = _.map(data.devicesStatus, function(device) { return device.device_id; }),
@@ -612,12 +611,6 @@ define(function(require) {
 				}
 			});
 
-			_.each(data.channels, function(val) {
-				if (channelsArray.indexOf(val.bridge_id) < 0) {
-					channelsArray.push(val.bridge_id);
-				}
-			});
-
 			if (data.mainNumbers && data.mainNumbers.length > 0) {
 				var bypassCnam = !monster.util.isNumberFeatureEnabled('cnam'),
 					isExternalNumberSet = _.has(data.numbers, _.get(data.account, 'caller_id.external.number')),
@@ -654,7 +647,6 @@ define(function(require) {
 				}
 			}
 
-			data.totalChannels = channelsArray.length;
 			data.devicesData = devices;
 			data.assignedNumbersData = assignedNumbers;
 			// data.numberTypesData = numberTypes;
@@ -665,6 +657,12 @@ define(function(require) {
 			}
 
 			return _.merge({
+				totalChannels: _
+					.chain(data.channels)
+					.map('bridge_id')
+					.uniq()
+					.size()
+					.value(),
 				totalConferences: _
 					.chain(data.users)
 					.reject(function(user) {

--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -419,6 +419,9 @@ define(function(require) {
 
 		myOfficeFormatData: function(data) {
 			var self = this,
+				getColorByIndex = function getColorByIndex(index) {
+					return self.chartColors[index % self.chartColors.length];
+				},
 				staticNumberStatuses = ['assigned', 'spare'],
 				devices = {
 					sip_device: {
@@ -619,7 +622,13 @@ define(function(require) {
 						return {
 							label: monster.util.tryI18n(self.i18n.active().myOffice.numberChartLegend, type),
 							count: _.size(numbers),
-							color: self.chartColors[_.indexOf(staticNumberStatuses, type) % self.chartColors.length]
+							color: _
+								.chain(staticNumberStatuses)
+								.indexOf(type)
+								.thru(function(index) {
+									return getColorByIndex((index * 5) + 3);
+								})
+								.value()
 						};
 					})
 					.value(),
@@ -647,7 +656,12 @@ define(function(require) {
 						return {
 							label: role.name,
 							count: _.get(userCountByServicePlanRole, id, 0),
-							color: self.chartColors[_.chain(roles).keys().indexOf(id).value() % self.chartColors.length]
+							color: _
+								.chain(roles)
+								.keys()
+								.indexOf(id)
+								.thru(getColorByIndex)
+								.value()
 						};
 					})
 					.value()

--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -35,7 +35,7 @@ define(function(require) {
 			'#BDE55F', // Light Green
 			'#F1E87C', // Pale Yellow
 			'#EF8F25', // Orange
-			'#6F7C7D'  // Grey
+			'#6F7C7D' // Grey
 		],
 
 		/* My Office */
@@ -80,7 +80,7 @@ define(function(require) {
 						// 	.orderBy('count', 'desc')
 						// 	.value(),
 						classifiedNumbers: myOfficeData.classifiedNumbers,
-						directoryUsers: myOfficeData.directory.users && myOfficeData.directory.users.length || 0,
+						directoryUsers: myOfficeData.directory.users && (myOfficeData.directory.users.length || 0),
 						directoryLink: myOfficeData.directoryLink,
 						showUserTypes: self.appFlags.global.showUserTypes
 					},
@@ -537,7 +537,7 @@ define(function(require) {
 					}
 					if (classifierRegexes[classifierKey].test(num)) {
 						if (classifierKey in classifiedNumbers) {
-							classifiedNumbers[classifierKey] ++;
+							classifiedNumbers[classifierKey] += 1;
 						} else {
 							classifiedNumbers[classifierKey] = 1;
 						}

--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -509,10 +509,6 @@ define(function(require) {
 				}(specialNumbers.mainNumbers, data.account, data.numbers)),
 				registeredDevices = _.map(data.devicesStatus, 'device_id');
 
-			if (data.directory && data.directory.id) {
-				data.directoryLink = self.apiUrl + 'accounts/' + self.accountId + '/directories/' + data.directory.id + '?accept=pdf&paginate=false&auth_token=' + self.getAuthToken();
-			}
-
 			return _.merge({
 				assignedNumbersData: _
 					.chain(data.numbers)
@@ -588,6 +584,7 @@ define(function(require) {
 						};
 					})
 					.value(),
+				directoryLink: _.has(data, 'directory.id') && self.apiUrl + 'accounts/' + self.accountId + '/directories/' + data.directory.id + '?accept=pdf&paginate=false&auth_token=' + self.getAuthToken(),
 				topMessage: topMessage,
 				totalChannels: _
 					.chain(data.channels)


### PR DESCRIPTION
The goal of this PR was to untangle the logic used to prepare and format data entities for the rendering of the "Dashboard" tab.

The main concern of this refactoring was to keep a similar output, as updating templates was out-of-scope as well as not introducing any regressions. A secondary concern was to preserve the datasets color scheme order so the end-users do not experience any visual change.

To review this PR, I'd recommend going through each commit individually as they are fairly self contained, and here is an (hopefully) exhaustive list explaining the more obscure parts of the code implemented to meet those concerns:

### Preserve coloring scheme

1. [For number statuses](https://github.com/2600hz/monster-ui-voip/pull/166/commits/49d500a573bfc0f14b17648b6578f52213ef4c80#diff-436b0db36fd89dedc678b61972cb5d35R628)

The original color scheme was `chartColors[3]` for spare numbers and `chartColors[8]` for assigned numbers; this formula in combination with storing statuses in an array preserves those colors.

2. [For device types](https://github.com/2600hz/monster-ui-voip/pull/166/commits/040ca2ddc4656adc0c50c8fdfa0475f055a07af6#diff-436b0db36fd89dedc678b61972cb5d35R422-R432)

This list is used to generate the same color scheme by using the index of each device type, meaning each type will always be rendered using the same color.

### Preserve feature parity

1. [Always display all known device types](https://github.com/2600hz/monster-ui-voip/pull/166/commits/040ca2ddc4656adc0c50c8fdfa0475f055a07af6#diff-436b0db36fd89dedc678b61972cb5d35R579-R581)

2. [Display classified numbers up to the max count of available colors](https://github.com/2600hz/monster-ui-voip/pull/166/commits/8cf60f6b9be969ee3aff393d91c8aa42cf8e9145#diff-436b0db36fd89dedc678b61972cb5d35R545-R554)

When the amount of classifiers reaches that limit, we use the last available slot to pack all the numbers we can't display under an "Others" classifier.