### PR TITLE
MSPB-102: Allow key function types filtering by brand for device edit form

### DIFF
--- a/submodules/devices/devices.js
+++ b/submodules/devices/devices.js
@@ -68,7 +68,8 @@ define(function(require) {
 					'sip_uri',
 					'smartphone',
 					'softphone'
-				]
+				],
+				provisionerConfigFlags: monster.config.provisioner
 			}
 		},
 
@@ -934,6 +935,19 @@ define(function(require) {
 		 */
 		devicesFormatData: function(data, dataList) {
 			var self = this,
+				deviceBrand = _.get(data, 'device.provision.endpoint_brand', null),
+				getDeviceAvailableFUnctions = function(brand) {
+					var availableFunctions = ['none', 'presence', 'parking', 'personal_parking', 'speed_dial'],
+						brandKey = 'brands.' + brand,
+						brandFlag = _.get(self.appFlags.devices.provisionerConfigFlags, brandKey, null),
+						deviceFunctions = _.get(brandFlag, 'functions', availableFunctions);
+
+					if (!brandFlag) {
+						return availableFunctions;
+					}
+
+					return _.intersection(availableFunctions, _.union(['none'], deviceFunctions));
+				},
 				isClassifierDisabledByAccount = function isClassifierDisabledByAccount(classifier) {
 					return _.get(data.accountLimits, ['call_restriction', classifier, 'action']) === 'deny';
 				},
@@ -1048,6 +1062,14 @@ define(function(require) {
 						};
 					}),
 					provision: {
+						keyActions: _.map(getDeviceAvailableFUnctions(deviceBrand), function(action) {
+							var i18n = self.i18n.active().devices.popupSettings.keys;
+							return {
+								id: action,
+								info: _.get(i18n, ['info', 'types', action]),
+								text: _.get(i18n, ['types', action])
+							};
+						}),
 						keys: _
 							.chain(data.template)
 							.thru(self.getKeyTypes)


### PR DESCRIPTION
Filter function types by a brand flag in `config.js`:  `provisioner.brands.<brand>.functions.<array>`

Example:

```
{
  provisioner: {
    brands: {
      avaya: {
        functions: [
        'presence',
        'parking',
        'speed_dial'
        ]       
      }
    }
  }
}
```
