### PR TITLE
'voicemails' not valid schema

### DIFF
--- a/submodules/groups/groups.js
+++ b/submodules/groups/groups.js
@@ -935,7 +935,7 @@ define(function(require) {
 					}, {
 						dataPath: 'voicemails',
 						label: self.i18n.active().groups.nextAction.voicemails,
-						module: 'voicemails',
+						module: 'voicemail',
 						entityValuePath: 'id',
 						entityLabelPath: 'name'
 					}, {


### PR DESCRIPTION
'voicemails' not valid schema. Corrected typo for valid 'callflows.voicemail' schema