### PR TITLE
MSPB-108: Avaya customizations

### DIFF
--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -164,6 +164,7 @@
 			"basicTitle": "Allgemeine Einstellungen",
 			"basicSectionTitle": "Allgemeine Einstellungen",
 			"dragAndDrop": "Um einen Codec auszuwählen, ziehen Sie diesen aus dem Feld „Verfügbare Codecs“ in das Feld „Ausgewählte Codecs“.",
+			"saveAndApply": "Speichern und anwenden",
 			"options": {
 				"menuTitle": "Optionen"
 			},

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -297,7 +297,7 @@
 			"keys": {
 				"alert": {
 					"message": "By default, this key will be used as a Line Key. It is strongly recommended that you not change it.",
-					"title": "Key 1 Default"
+					"title": "Key {{variable}} Default"
 				},
 				"featureKeys": {
 					"menuTitle": "Feature Keys",

--- a/submodules/devices/devices.js
+++ b/submodules/devices/devices.js
@@ -940,6 +940,11 @@ define(function(require) {
 					['brands', _.get(data.device, 'provision.endpoint_brand'), 'keyFunctions'],
 					[]
 				),
+				defaultLineKeys = _.get(
+					self.appFlags.devices.provisionerConfigFlags,
+					['brands', _.get(data.device, 'provision.endpoint_brand'), 'lineKeys'],
+					[1]
+				),
 				isClassifierDisabledByAccount = function isClassifierDisabledByAccount(classifier) {
 					return _.get(data.accountLimits, ['call_restriction', classifier, 'action']) === 'deny';
 				},
@@ -1066,6 +1071,7 @@ define(function(require) {
 								return _.merge({
 									id: type,
 									type: camelCasedType,
+									lineKeys: defaultLineKeys,
 									actions: _
 										.chain([
 											'presence',
@@ -1096,10 +1102,10 @@ define(function(require) {
 												: a.label.localeCompare(b.label, monster.config.whitelabel.language);
 										})
 										.value(),
-									data: _.map(entries, function(metadata) {
+									data: _.map(entries, function(metadata, idx) {
 										var value = _.get(metadata, 'value', {});
 
-										return _.merge({}, metadata, _.isPlainObject(value)
+										return _.merge({ keyNumber: idx + 1 }, metadata, _.isPlainObject(value)
 											? {}
 											: {
 												value: {

--- a/submodules/devices/devices.scss
+++ b/submodules/devices/devices.scss
@@ -254,6 +254,10 @@
 	padding: 15px 0;
 }
 
+.voip-edit-device-popup .edit-device .device-title .device-model {
+	text-transform: uppercase;
+}
+
 .voip-edit-device-popup .edit-device .title-bar .device-title > div {
 	float: left;
 	font-size: 18px;

--- a/submodules/devices/views/devices-sip_device.html
+++ b/submodules/devices/views/devices-sip_device.html
@@ -348,13 +348,13 @@
 				</div>
 				<div class="section-content">
 				{{#each data}}
-					<div class="control-group{{#compare ../id '===' 'combo_keys'}}{{#if @first}} warning{{/if}}{{/compare}}" data-id="{{@index}}">
+					<div class="control-group{{#compare ../id '===' 'combo_keys'}}{{#ifInArray keyNumber ../lineKeys}} warning{{/ifInArray}}{{/compare}}" data-id="{{@index}}">
 						<label for="provision.keys.{{../id}}[{{@index}}].type" class="control-label">
 							{{telicon 'drag-handle' class='drag-handle-icon'}}
-							<span>{{ ../label }}</span> <span class="feature-key-index">{{@index}}</span>
+							<span>{{ ../label }} {{keyNumber}}</span>
 						</label>
 						{{#compare ../id '===' 'combo_keys'}}
-							{{#monsterPanelText @root.i18n.devices.popupSettings.keys.alert.title 'warning' 'fill-width'}}
+							{{#monsterPanelText (replaceVar @root.i18n.devices.popupSettings.keys.alert.title keyNumber) 'warning' 'fill-width'}}
 								{{@root.i18n.devices.popupSettings.keys.alert.message}}
 							{{/monsterPanelText}}
 						{{/compare}}


### PR DESCRIPTION
To set default line keys by a brand you need to use a flag in config.js: provisioner.brands.<brand>.lineKeys.<array>

Example: 

```javascript
provisioner: {
	brands: {
		avaya: {
			lineKeys: [1, 2]
		}
	}
}
```