### PR TITLE
MSPB-131: Update linked callflow on mobile device un\assignment

### DIFF
--- a/app.js
+++ b/app.js
@@ -254,54 +254,6 @@ define(function(require) {
 				_.partial(getMobileCallflowIdByNumber, device.mobile.mdn),
 				_.partial(patchCallflow, updatedCallflow)
 			], mainCallback);
-		},
-
-		updateDeviceAssignmentFromUser: function(deviceId, userId, userMainCallflowId, mainCallback) {
-			var self = this,
-				getDevice = function getDevice(deviceId, callback) {
-					self.callApi({
-						resource: 'device.get',
-						data: {
-							accountId: self.accountId,
-							deviceId: deviceId
-						},
-						success: _.flow(
-							_.partial(_.get, _, 'data'),
-							_.partial(callback, null)
-						),
-						error: _.partial(callback, true)
-					});
-				},
-				patchDevice = function patchDevice(data, deviceId, callback) {
-					self.callApi({
-						resource: 'device.patch',
-						data: {
-							accountId: self.accountId,
-							deviceId: deviceId,
-							data: data
-						},
-						success: _.flow(
-							_.partial(_.get, _, 'data'),
-							_.partial(callback, null)
-						),
-						error: _.partial(callback, true)
-					});
-				},
-				updateDeviceAssignment = function updateDeviceAssignment(userId, userMainCallflowId, device, callback) {
-					var updatedDevice = {
-						owner_id: userId
-					};
-
-					monster.parallel([
-						_.bind(self.maybeUpdateMobileCallflow, self, userId, userMainCallflowId, device),
-						_.partial(patchDevice, updatedDevice, device.id)
-					], callback);
-				};
-
-			monster.waterfall([
-				_.partial(getDevice, deviceId),
-				_.partial(updateDeviceAssignment, userId, userMainCallflowId)
-			], mainCallback);
 		}
 	};
 

--- a/app.js
+++ b/app.js
@@ -196,41 +196,6 @@ define(function(require) {
 			});
 		},
 
-		getDevice: function(deviceId, callback) {
-			var self = this;
-
-			self.callApi({
-				resource: 'device.get',
-				data: {
-					accountId: self.accountId,
-					deviceId: deviceId
-				},
-				success: _.flow(
-					_.partial(_.get, _, 'data'),
-					_.partial(callback, null)
-				),
-				error: _.partial(callback, true)
-			});
-		},
-
-		patchDevice: function(data, deviceId, callback) {
-			var self = this;
-
-			self.callApi({
-				resource: 'device.patch',
-				data: {
-					accountId: self.accountId,
-					deviceId: deviceId,
-					data: data
-				},
-				success: _.flow(
-					_.partial(_.get, _, 'data'),
-					_.partial(callback, null)
-				),
-				error: _.partial(callback, true)
-			});
-		},
-
 		getMobileCallflowIdByNumber: function(number, callback) {
 			var self = this;
 
@@ -270,6 +235,35 @@ define(function(require) {
 
 		updateDeviceAssignmentFromUser: function(deviceId, userId, userMainCallflowId, mainCallback) {
 			var self = this,
+				getDevice = function getDevice(deviceId, callback) {
+					self.callApi({
+						resource: 'device.get',
+						data: {
+							accountId: self.accountId,
+							deviceId: deviceId
+						},
+						success: _.flow(
+							_.partial(_.get, _, 'data'),
+							_.partial(callback, null)
+						),
+						error: _.partial(callback, true)
+					});
+				},
+				patchDevice = function patchDevice(data, deviceId, callback) {
+					self.callApi({
+						resource: 'device.patch',
+						data: {
+							accountId: self.accountId,
+							deviceId: deviceId,
+							data: data
+						},
+						success: _.flow(
+							_.partial(_.get, _, 'data'),
+							_.partial(callback, null)
+						),
+						error: _.partial(callback, true)
+					});
+				},
 				maybeUpdateMobileCallflow = function maybeUpdateMobileCallflow(userId, userMainCallflowId, device, callback) {
 					if (device.device_type !== 'mobile') {
 						return callback(null);
@@ -304,12 +298,12 @@ define(function(require) {
 
 					monster.waterfall([
 						_.partial(maybeUpdateMobileCallflow, userId, userMainCallflowId, device),
-						_.bind(self.patchDevice, self, updatedDevice, device.id)
+						_.partial(patchDevice, updatedDevice, device.id)
 					], callback);
 				};
 
 			monster.waterfall([
-				_.bind(self.getDevice, self, deviceId),
+				_.partial(getDevice, deviceId),
 				_.partial(updateDeviceAssignment, userId, userMainCallflowId)
 			], mainCallback);
 		}

--- a/app.js
+++ b/app.js
@@ -268,7 +268,7 @@ define(function(require) {
 			});
 		},
 
-		assignDeviceToUser: function assignDeviceToUser(deviceId, userId, userMainCallflowId, mainCallback) {
+		updateDeviceAssignmentFromUser: function(deviceId, userId, userMainCallflowId, mainCallback) {
 			var self = this,
 				maybeUpdateMobileCallflow = function maybeUpdateMobileCallflow(userId, userMainCallflowId, device, callback) {
 					if (device.device_type !== 'mobile') {
@@ -297,7 +297,7 @@ define(function(require) {
 						_.bind(self.patchCallflow, self, updatedCallflow)
 					], callback);
 				},
-				assignDeviceToUser = function assignDeviceToUser(userId, userMainCallflowId, device, callback) {
+				updateDeviceAssignment = function updateDeviceAssignment(userId, userMainCallflowId, device, callback) {
 					var updatedDevice = {
 						owner_id: userId
 					};
@@ -310,45 +310,7 @@ define(function(require) {
 
 			monster.waterfall([
 				_.bind(self.getDevice, self, deviceId),
-				_.partial(assignDeviceToUser, userId, userMainCallflowId)
-			], mainCallback);
-		},
-
-		unassignDeviceFromUser: function unassignDeviceFromUser(deviceId, userId, mainCallback) {
-			var self = this,
-				maybeUpdateMobileCallflow = function maybeUpdateMobileCallflow(userId, device, callback) {
-					if (device.device_type !== 'mobile') {
-						return callback(null);
-					}
-					var updatedCallflow = {
-						owner_id: null,
-						flow: {
-							module: 'device',
-							data: {
-								id: device.id
-							}
-						}
-					};
-
-					monster.waterfall([
-						_.bind(self.getMobileCallflowIdByNumber, self, device.mobile.mdn),
-						_.bind(self.patchCallflow, self, updatedCallflow)
-					], callback);
-				},
-				unassignDeviceFromUser = function unassignDeviceFromUser(userId, device, callback) {
-					var updatedDevice = {
-						owner_id: null
-					};
-
-					monster.waterfall([
-						_.partial(maybeUpdateMobileCallflow, userId, device),
-						_.bind(self.patchDevice, self, updatedDevice, device.id)
-					], callback);
-				};
-
-			monster.waterfall([
-				_.bind(self.getDevice, self, deviceId),
-				_.partial(unassignDeviceFromUser)
+				_.partial(updateDeviceAssignment, userId, userMainCallflowId)
 			], mainCallback);
 		}
 	};

--- a/app.js
+++ b/app.js
@@ -292,7 +292,7 @@ define(function(require) {
 						owner_id: userId
 					};
 
-					monster.waterfall([
+					monster.parallel([
 						_.bind(self.maybeUpdateMobileCallflow, self, userId, userMainCallflowId, device),
 						_.partial(patchDevice, updatedDevice, device.id)
 					], callback);

--- a/app.js
+++ b/app.js
@@ -205,16 +205,16 @@ define(function(require) {
 		 * @param  {String} device.mobile.mdn
 		 * @param  {Function} mainCallback
 		 *
-		 * updateMobileCallflow(userId, userMainCallflowId|undefined, ...)
+		 * updateMobileCallflowAssignment(userId, userMainCallflowId|undefined, ...)
 		 * this signature will assign the device
 		 *
-		 * updateMobileCallflow(null, null, ...)
+		 * updateMobileCallflowAssignment(null, null, ...)
 		 * this signature will unassign the device
 		 *
 		 * While assigning, you can either provide the user's main callflow's ID or set it to
 		 * `undefined`, in which case the method will take care of resolving it based on `userId`.
 		 */
-		updateMobileCallflow: function(userId, userMainCallflowId, device, mainCallback) {
+		updateMobileCallflowAssignment: function(userId, userMainCallflowId, device, mainCallback) {
 			var self = this,
 				getMainUserCallflowId = function getMainUserCallflowId(userId, callback) {
 					self.callApi({
@@ -278,7 +278,7 @@ define(function(require) {
 						error: _.partial(callback, true)
 					});
 				},
-				updateMobileCallflow = function updateMobileCallflow(userId, deviceId, callflowIds, callback) {
+				updateMobileCallflowAssignment = function updateMobileCallflowAssignment(userId, deviceId, callflowIds, callback) {
 					var userMainCallflowId = callflowIds.userMainCallflowId,
 						mobileCallflowId = callflowIds.mobileCallflowId,
 						updatedCallflow = _.merge({
@@ -304,7 +304,7 @@ define(function(require) {
 
 			monster.waterfall([
 				_.partial(getCallflowIds, userId, userMainCallflowId, device.mobile.mdn),
-				_.partial(updateMobileCallflow, userId, device.id)
+				_.partial(updateMobileCallflowAssignment, userId, device.id)
 			], mainCallback);
 		}
 	};

--- a/app.js
+++ b/app.js
@@ -231,18 +231,39 @@ define(function(require) {
 			});
 		},
 
+		getMobileCallflowIdByNumber: function(number, callback) {
+			var self = this;
+
+			self.callApi({
+				resource: 'callflow.searchByNumber',
+				data: {
+					accountId: self.accountId,
+					value: number
+				},
+				success: _.flow(
+					_.partial(_.get, _, 'data'),
+					_.head,
+					_.partial(_.get, _, 'id'),
+					_.partial(callback, null)
+				),
+				error: _.partial(callback, true)
+			});
+		},
+
 		assignDeviceToUser: function assignDeviceToUser(deviceId, userId, userMainCallflowId, mainCallback) {
 			var self = this,
 				maybeUpdateMobileCallflow = function maybeUpdateMobileCallflow(userId, userMainCallflowId, device, callback) {
 					if (device.device_type !== 'mobile') {
 						return callback(null);
 					}
-					self.usersSearchMobileCallflowsByNumber(userId, device.mobile.mdn, function(listCallflowData) {
+					monster.waterfall([
+						_.bind(self.getMobileCallflowIdByNumber, self, device.mobile.mdn)
+					], function(err, callflowId) {
 						self.callApi({
 							resource: 'callflow.get',
 							data: {
 								accountId: self.accountId,
-								callflowId: listCallflowData.id
+								callflowId: callflowId
 							},
 							success: function(rawCallflowData, status) {
 								var callflowData = rawCallflowData.data;
@@ -297,12 +318,14 @@ define(function(require) {
 					if (device.device_type !== 'mobile') {
 						return callback(null);
 					}
-					self.usersSearchMobileCallflowsByNumber(userId, device.mobile.mdn, function(listCallflowData) {
+					monster.waterfall([
+						_.bind(self.getMobileCallflowIdByNumber, self, device.mobile.mdn)
+					], function(err, callflowId) {
 						self.callApi({
 							resource: 'callflow.get',
 							data: {
 								accountId: self.accountId,
-								callflowId: listCallflowData.id
+								callflowId: callflowId
 							},
 							success: function(rawCallflowData, status) {
 								var callflowData = rawCallflowData.data;

--- a/app.js
+++ b/app.js
@@ -204,10 +204,29 @@ define(function(require) {
 			});
 		},
 
+		getDevice: function(deviceId, callback) {
+			var self = this;
+
+			self.callApi({
+				resource: 'device.get',
+				data: {
+					accountId: self.accountId,
+					deviceId: deviceId
+				},
+				success: _.flow(
+					_.partial(_.get, _, 'data'),
+					_.partial(callback, null)
+				),
+				error: _.partial(callback, true)
+			});
+		},
+
 		assignDeviceToUser: function assignDeviceToUser(deviceId, userId, userCallflowId, callback) {
 			var self = this;
 
-			self.usersGetDevice(deviceId, function(data) {
+			monster.waterfall([
+				_.bind(self.getDevice, self, deviceId)
+			], function(err, data) {
 				data.owner_id = userId;
 
 				if (data.device_type === 'mobile') {
@@ -258,7 +277,9 @@ define(function(require) {
 		unassignDeviceFromUser: function unassignDeviceFromUser(deviceId, userId, callback) {
 			var self = this;
 
-			self.usersGetDevice(deviceId, function(data) {
+			monster.waterfall([
+				_.bind(self.getDevice, self, deviceId)
+			], function(err, data) {
 				delete data.owner_id;
 
 				if (data.device_type === 'mobile') {

--- a/submodules/devices/devices.js
+++ b/submodules/devices/devices.js
@@ -1456,13 +1456,10 @@ define(function(require) {
 		 * @param  {Function} [callbackError]
 		 */
 		devicesSaveDevice: function(deviceData, callbackSuccess, callbackError) {
-			var self = this;
+			var self = this,
+				method = deviceData.id ? 'devicesUpdateDevice' : 'devicesCreateDevice';
 
-			if (deviceData.id) {
-				self.devicesUpdateDevice(deviceData, callbackSuccess, callbackError);
-			} else {
-				self.devicesCreateDevice(deviceData, callbackSuccess, callbackError);
-			}
+			self[method](deviceData, callbackSuccess, callbackError);
 		},
 
 		/**

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -4728,21 +4728,6 @@ define(function(require) {
 			});
 		},
 
-		usersGetDevice: function(deviceId, callback) {
-			var self = this;
-
-			self.callApi({
-				resource: 'device.get',
-				data: {
-					accountId: self.accountId,
-					deviceId: deviceId
-				},
-				success: function(data) {
-					callback(data.data);
-				}
-			});
-		},
-
 		usersUpdateDevice: function(data, callback) {
 			var self = this;
 

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -4812,10 +4812,10 @@ define(function(require) {
 			self.usersGetMainCallflow(userId, function(userCallflow) {
 				var listFnParallel = _.flatten([
 					_.map(data.newDevices, function(deviceId) {
-						return _.bind(self.assignDeviceToUser, self, deviceId, userId, _.get(userCallflow, 'id'));
+						return _.bind(self.updateDeviceAssignmentFromUser, self, deviceId, userId, _.get(userCallflow, 'id'));
 					}),
 					_.map(data.oldDevices, function(deviceId) {
-						return _.bind(self.unassignDeviceFromUser, self, deviceId, userId);
+						return _.bind(self.updateDeviceAssignmentFromUser, self, deviceId, null, undefined);
 					})
 				]);
 

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -4815,7 +4815,7 @@ define(function(require) {
 						return _.bind(self.usersUpdateDeviceAssignmentFromUser, self, deviceId, userId, _.get(userCallflow, 'id'));
 					}),
 					_.map(data.oldDevices, function(deviceId) {
-						return _.bind(self.usersUpdateDeviceAssignmentFromUser, self, deviceId, null, undefined);
+						return _.bind(self.usersUpdateDeviceAssignmentFromUser, self, deviceId, null, null);
 					})
 				]);
 
@@ -4888,13 +4888,19 @@ define(function(require) {
 						error: _.partial(callback, true)
 					});
 				},
+				maybeUpdateMobileCallflow = function maybeUpdateMobileCallflow(userId, userMainCallflowId, device, callback) {
+					if (device.device_type !== 'mobile') {
+						return callback(null);
+					}
+					self.updateMobileCallflow(userId, userMainCallflowId, device, callback);
+				},
 				updateDeviceAssignment = function updateDeviceAssignment(userId, userMainCallflowId, device, callback) {
 					var updatedDevice = {
 						owner_id: userId
 					};
 
 					monster.parallel([
-						_.bind(self.maybeUpdateMobileCallflow, self, userId, userMainCallflowId, device),
+						_.partial(maybeUpdateMobileCallflow, userId, userMainCallflowId, device),
 						_.partial(patchDevice, updatedDevice, device.id)
 					], callback);
 				};

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -4888,11 +4888,11 @@ define(function(require) {
 						error: _.partial(callback, true)
 					});
 				},
-				maybeUpdateMobileCallflow = function maybeUpdateMobileCallflow(userId, userMainCallflowId, device, callback) {
+				maybeUpdateMobileCallflowAssignment = function maybeUpdateMobileCallflowAssignment(userId, userMainCallflowId, device, callback) {
 					if (device.device_type !== 'mobile') {
 						return callback(null);
 					}
-					self.updateMobileCallflow(userId, userMainCallflowId, device, callback);
+					self.updateMobileCallflowAssignment(userId, userMainCallflowId, device, callback);
 				},
 				updateDeviceAssignment = function updateDeviceAssignment(userId, userMainCallflowId, device, callback) {
 					var updatedDevice = {
@@ -4900,7 +4900,7 @@ define(function(require) {
 					};
 
 					monster.parallel([
-						_.partial(maybeUpdateMobileCallflow, userId, userMainCallflowId, device),
+						_.partial(maybeUpdateMobileCallflowAssignment, userId, userMainCallflowId, device),
 						_.partial(patchDevice, updatedDevice, device.id)
 					], callback);
 				};

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -4728,22 +4728,6 @@ define(function(require) {
 			});
 		},
 
-		usersUpdateDevice: function(data, callback) {
-			var self = this;
-
-			self.callApi({
-				resource: 'device.update',
-				data: {
-					accountId: self.accountId,
-					data: data,
-					deviceId: data.id
-				},
-				success: function(data) {
-					callback(data.data);
-				}
-			});
-		},
-
 		usersListDeviceUser: function(userId, callback) {
 			var self = this;
 


### PR DESCRIPTION
The goal of this PR is to update the callflow related to a mobile device when such a device gets un\assigned under the "Devices" module as it currently only updates the device entity.

Since the logic to achieve that callflow update already exists for the "Users" module, a lot of refactoring took place to [extract ](https://github.com/2600hz/monster-ui-voip/pull/254/files#diff-0364f57fbff2fabbe941ed20c328ef1aR234)it into its own method so it can be reused [in](https://github.com/2600hz/monster-ui-voip/pull/254/files#diff-9d41170cfbf87d93b3bc4cb8b757ef0cR1471) different [places](https://github.com/2600hz/monster-ui-voip/pull/254/files#diff-3f48311df930d8c96c10dc025d5a2417R4933).

Another improvement made in this PR, which is a direct consequence of extracting common logic into reusable methods, is that some operations take less time, as they are now triggered in parallel when possible or use patches instead of fetch and update.