### PR TITLE
MSPB-133: Set owner ID to device on creation

### DIFF
--- a/submodules/devices/devices.js
+++ b/submodules/devices/devices.js
@@ -274,9 +274,11 @@ define(function(require) {
 				ownerId = _.get(args, 'ownerId'),
 				type = args.type,
 				callback = args.callback,
-				data = {
+				data = _.merge({
 					device_type: type
-				};
+				}, ownerId && {
+					owner_id: ownerId
+				});
 
 			if (type === 'sip_device' && monster.config.api.provisioner) {
 				monster.pub('common.chooseModel.render', {

--- a/submodules/devices/devices.js
+++ b/submodules/devices/devices.js
@@ -264,12 +264,14 @@ define(function(require) {
 		/**
 		 * @param  {Object} args
 		 * @param  {Boolean} [args.allowAssign]
+		 * @param  {Boolean} [args.ownerId]
 		 * @param  {String} args.type
 		 * @param  {Function} args.callback
 		 */
 		devicesRenderAdd: function(args) {
 			var self = this,
 				allowAssign = _.get(args, 'allowAssign'),
+				ownerId = _.get(args, 'ownerId'),
 				type = args.type,
 				callback = args.callback,
 				data = {
@@ -283,7 +285,7 @@ define(function(require) {
 							resource: 'device.create',
 							data: {
 								accountId: self.accountId,
-								data: dataModel
+								data: _.merge({}, dataModel, ownerId && { owner_id: ownerId })
 							},
 							success: function(data, status) {
 								callback(data.data);

--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -1162,6 +1162,7 @@ define(function(require) {
 
 				monster.pub('voip.devices.renderAdd', {
 					allowAssign: false,
+					ownerId: currentUser,
 					type: type,
 					callback: function(device) {
 						var rowDevice = $(self.getTemplate({


### PR DESCRIPTION
It seems that the device was not assigned to the respective user, when it was added in the Users tab. This change sets the `owner_id` to the device on creation.

4.3 -> #258
5.0 -> #259