### PR TITLE
MSPB-180: Re-add outbound privacy options to appFlags

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,13 @@ define(function(require) {
 		appFlags: {
 			common: {
 				hasProvisioner: false,
+				outboundPrivacy: [
+					'default',
+					'none',
+					'number',
+					'name',
+					'full'
+				],
 				callRecording: {
 					supportedAudioFormats: [
 						'mp3',


### PR DESCRIPTION
The outbound privacy options seem to be accidentally removed by #336 