### PR TITLE
PROD-169: split failover from forward

### DIFF
--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -215,7 +215,7 @@ define(function(require) {
 							iconColor: 'monster-blue',
 							title: self.i18n.active().users.caller_id.title
 						},
-						call_forward_failover: {
+						call_failover: {
 							icon: 'fa fa-share',
 							iconColor: 'monster-orange',
 							title: self.i18n.active().users.call_forward.failover_title,


### PR DESCRIPTION
Duplicate call forwarding settings into a failover object (account, user, device) and remove ‘failover’ as a call forward option.

The intend is to allow users to be able to change their call forwarding settings without impacting the failover settings and have failover set independently from forward.