### PR TITLE
MSPB-167: Add given main number as e911 if it's valid

### DIFF
--- a/submodules/strategy/strategy.js
+++ b/submodules/strategy/strategy.js
@@ -1115,7 +1115,8 @@ define(function(require) {
 						var callFlowNumbers = self.strategyExtractMainNumbers({
 								mainCallflow: updatedCallflow
 							}),
-							hasEmergencyCID = _.chain(monster.apps.auth.currentAccount).get('caller_id.emergency.number').isEmpty().value();
+							hasEmergencyCID = _.chain(monster.apps.auth.currentAccount).get('caller_id.emergency.number').isEmpty().value(),
+							hasExternalCID = _.chain(monster.apps.auth.currentAccount).get('caller_id.external.number').isEmpty().value();
 
 						strategyData.callflows.MainCallflow = updatedCallflow;
 						refreshNumbersTemplate();
@@ -1124,7 +1125,7 @@ define(function(require) {
 							numbers: callFlowNumbers
 						});
 
-						if (hasEmergencyCID) {
+						if (hasEmergencyCID && hasExternalCID) {
 							self.strategySetupEmergencyCID(newNumberId);
 						}
 					});


### PR DESCRIPTION
...considerations
1. If the account already a emergency cid, it doesn't do anything
2. If there is no emergency cid in the account, we check if the given number already have the e911 setup, if true, is added as emergency cid.
[5.0](https://github.com/2600hz/monster-ui-voip/pull/390)