### PR TITLE
[5.0] MSPB-167: Add given main number as e911 if it's valid

### DIFF
--- a/submodules/strategy/strategy.js
+++ b/submodules/strategy/strategy.js
@@ -529,31 +529,33 @@ define(function(require) {
 					});
 				},
 				function(numberData, cb) {
-					var isE911Enabled = _.chain(numberData).get('features').includes('e911').value();
+					var isE911Enabled = _
+						.chain(numberData)
+						.get('features')
+						.includes('e911')
+						.value();
 
-					if (isE911Enabled) {
-						self.strategyChangeCallerId({
-							callerIdType: 'emergency',
-							number: number,
-							success: function() {
-								monster.ui.toast({
-									type: 'success',
-									message: self.getTemplate({
-										name: '!' + self.i18n.active().strategy.updateCallerIdDialog.success.emergency,
-										data: {
-											number: monster.util.formatPhoneNumber(number)
-										}
-									})
-								});
-
-								cb(null);
-							}
-						});
-
-						return;
+					if (!isE911Enabled) {
+						return cb(null);
 					}
 
-					cb(null);
+					self.strategyChangeCallerId({
+						callerIdType: 'emergency',
+						number: number,
+						success: function() {
+							monster.ui.toast({
+								type: 'success',
+								message: self.getTemplate({
+									name: '!' + self.i18n.active().strategy.updateCallerIdDialog.success.emergency,
+									data: {
+										number: monster.util.formatPhoneNumber(number)
+									}
+								})
+							});
+
+							cb(null);
+						}
+					});
 				}
 			]);
 		},
@@ -1143,8 +1145,16 @@ define(function(require) {
 						var callFlowNumbers = self.strategyExtractMainNumbers({
 								mainCallflow: updatedCallflow
 							}),
-							hasEmergencyCID = _.chain(monster.apps.auth.currentAccount).get('caller_id.emergency.number').isEmpty().value(),
-							hasExternalCID = _.chain(monster.apps.auth.currentAccount).get('caller_id.external.number').isEmpty().value();
+							shouldSetupEmergencyCid = _
+								.chain([
+									'external',
+									'emergency'
+								])
+								.map(function(cid) {
+									return _.get(monster.apps.auth.currentAccount, ['caller_id', cid, 'number'], '');
+								})
+								.every(_.isEmpty)
+								.value();
 
 						strategyData.callflows.MainCallflow = updatedCallflow;
 						refreshNumbersTemplate();
@@ -1153,7 +1163,7 @@ define(function(require) {
 							numbers: callFlowNumbers
 						});
 
-						if (hasEmergencyCID && hasExternalCID) {
+						if (shouldSetupEmergencyCid) {
 							self.strategySetupEmergencyCID(newNumberId);
 						}
 					});

--- a/submodules/strategy/strategy.js
+++ b/submodules/strategy/strategy.js
@@ -519,6 +519,45 @@ define(function(require) {
 			});
 		},
 
+		strategySetupEmergencyCID: function(number) {
+			var self = this;
+
+			monster.waterfall([
+				function(cb) {
+					self.strategyGetNumber(number, function(numberData) {
+						cb(null, numberData);
+					});
+				},
+				function(numberData, cb) {
+					var isE911Enabled = _.chain(numberData).get('features').includes('e911').value();
+
+					if (isE911Enabled) {
+						self.strategyChangeCallerId({
+							callerIdType: 'emergency',
+							number: number,
+							success: function() {
+								monster.ui.toast({
+									type: 'success',
+									message: self.getTemplate({
+										name: '!' + self.i18n.active().strategy.updateCallerIdDialog.success.emergency,
+										data: {
+											number: monster.util.formatPhoneNumber(number)
+										}
+									})
+								});
+
+								cb(null);
+							}
+						});
+
+						return;
+					}
+
+					cb(null);
+				}
+			]);
+		},
+
 		/**
 		 * Check if it is necessary to update the emergency caller ID for the account
 		 * @param  {Object}   args
@@ -1086,6 +1125,7 @@ define(function(require) {
 		strategyNumbersBindEvents: function(container, strategyData) {
 			var self = this,
 				addNumbersToMainCallflow = function(numbers) {
+					var newNumberId = _.head(numbers);
 					if (_.isEmpty(numbers)) {
 						return;
 					}
@@ -1100,14 +1140,21 @@ define(function(require) {
 					mainCallflow.numbers = mainCallflow.numbers.concat(numbers);
 
 					self.strategyUpdateCallflow(mainCallflow, function(updatedCallflow) {
+						var callFlowNumbers = self.strategyExtractMainNumbers({
+								mainCallflow: updatedCallflow
+							}),
+							hasEmergencyCID = _.chain(monster.apps.auth.currentAccount).get('caller_id.emergency.number').isEmpty().value();
+
 						strategyData.callflows.MainCallflow = updatedCallflow;
 						refreshNumbersTemplate();
 
 						self.strategyCheckIfSetExternalCallerID({
-							numbers: self.strategyExtractMainNumbers({
-								mainCallflow: updatedCallflow
-							})
+							numbers: callFlowNumbers
 						});
+
+						if (hasEmergencyCID) {
+							self.strategySetupEmergencyCID(newNumberId);
+						}
 					});
 				},
 				refreshNumbersTemplate = function() {

--- a/submodules/strategy/strategy.js
+++ b/submodules/strategy/strategy.js
@@ -1143,7 +1143,8 @@ define(function(require) {
 						var callFlowNumbers = self.strategyExtractMainNumbers({
 								mainCallflow: updatedCallflow
 							}),
-							hasEmergencyCID = _.chain(monster.apps.auth.currentAccount).get('caller_id.emergency.number').isEmpty().value();
+							hasEmergencyCID = _.chain(monster.apps.auth.currentAccount).get('caller_id.emergency.number').isEmpty().value(),
+							hasExternalCID = _.chain(monster.apps.auth.currentAccount).get('caller_id.external.number').isEmpty().value();
 
 						strategyData.callflows.MainCallflow = updatedCallflow;
 						refreshNumbersTemplate();
@@ -1152,7 +1153,7 @@ define(function(require) {
 							numbers: callFlowNumbers
 						});
 
-						if (hasEmergencyCID) {
+						if (hasEmergencyCID && hasExternalCID) {
 							self.strategySetupEmergencyCID(newNumberId);
 						}
 					});


### PR DESCRIPTION
...considerations
1. If the account already a emergency cid, it doesn't do anything
2. If there is no emergency cid in the account, we check if the given number already have the e911 setup, if true, is added as emergency cid.