### PR TITLE
[5.1] PROD-169: split failover from forward

### DIFF
--- a/submodules/users/users.js
+++ b/submodules/users/users.js
@@ -222,7 +222,7 @@ define(function(require) {
 							iconColor: 'monster-blue',
 							title: self.i18n.active().users.caller_id.title
 						},
-						call_forward_failover: {
+						call_failover: {
 							icon: 'fa fa-share',
 							iconColor: 'monster-orange',
 							title: self.i18n.active().users.call_forward.failover_title,


### PR DESCRIPTION
Duplicate call forwarding settings into a fail over object (account, user, device) and remove ‘fail over’ as a call forward option.

The intend is to allow users to be able to change their call forwarding settings without impacting the fail over settings and have fail over set independently from forward.