### PR TITLE
[5.1] MSPB-323: Delete feature codes with same names as SPBX ones

### DIFF
--- a/submodules/strategy/strategy.js
+++ b/submodules/strategy/strategy.js
@@ -2898,9 +2898,6 @@ define(function(require) {
 								_.partial(_.isEqual, _.get(callflow, 'featurecode.name'))
 							]));
 						})
-						.tap(function(callflows) {
-							console.log('monster-ui-voip:strategy:strategyHandleFeatureCodes:maybeDeleteWrongFeatureCodes', callflows);
-						})
 						.map(deleteFeatureCodeFactory)
 						.value()
 					, function() {
@@ -2914,9 +2911,6 @@ define(function(require) {
 							_.unary(_.partial(_.get, _, 'name')),
 							_.partial(_.includes, _.map(existing, 'featurecode.name'))
 						]))
-						.tap(function(configs) {
-							console.log('monster-ui-voip:strategy:strategyHandleFeatureCodes:maybeCreateMissingFeatureCodes', configs);
-						})
 						.map(createFeatureCodeFactory)
 						.value()
 					, callback);


### PR DESCRIPTION
When loading the Main Number page, delete any callflows that have the same feature code name as the ones automatically created by the Smart PBX ap, but that have been created outside of this app.