### PR TITLE
[5.3] MSPB-341: Adding a Smartphone Device in SPBX Errors out

### DIFF
--- a/submodules/devices/devices.js
+++ b/submodules/devices/devices.js
@@ -740,12 +740,6 @@ define(function(require) {
 					keep_caller_id: true
 				}, formData.call_forward);
 
-				if (originalData.device_type === 'smartphone') {
-					formData.call_failover = _.merge({
-						enabled: true
-					}, formData.call_failover);
-				}
-
 				if (formData.hasOwnProperty('extra') && formData.extra.allowVMCellphone) {
 					formData.call_forward.require_keypress = !formData.extra.allowVMCellphone;
 				}


### PR DESCRIPTION
This removes the section call_failover when creating a new Smartphone device, this is due to a change in the API that split call_forward.number from call_failover.number: https://github.com/2600hz/kazoo-crossbar/pull/179.

As a result it was decided to remove the call_failover section of the payload ([accounts.md#call_failover](https://github.com/2600hz/kazoo-crossbar/blob/master/doc/accounts.md#call_failover)) and keep it only available through the API.