### PR TITLE
[5.4] MSPB-385: Add `tts.voice` `whitelabel` support

### DIFF
--- a/submodules/strategy/strategy.js
+++ b/submodules/strategy/strategy.js
@@ -2368,7 +2368,7 @@ define(function(require) {
 								media_source: 'tts',
 								description: '<Text to Speech>',
 								tts: {
-									voice: 'female/en-US',
+									voice: monster.config.whitelabel.ttsVoice || monster.defaultTTSVoice,
 									text: text
 								}
 							}


### PR DESCRIPTION
- Enabling `whitelabel` support for `tts.voice` changes in SmartPBX