### PR TITLE
MSPB-390: add `timeout` option to SmartPBX incoming call handling

### DIFF
--- a/submodules/strategy/views/menuLine.html
+++ b/submodules/strategy/views/menuLine.html
@@ -13,6 +13,7 @@
 		<option value="7">7</option>
 		<option value="8">8</option>
 		<option value="9">9</option>
+		<option value="timeout">timeout</option>
 		<option value="*">*</option>
 	{{/select}}
 	</select>


### PR DESCRIPTION
Add `timeout` selection to SmartPBX Main Number incoming call handling to match functionality available in Callflows. Executes configured `timeout` `child` `flow` when no user input is received within timeout period.

**API Change:**
```diff
"children": {
  "0": { ... },
  "1": { ... },
+ "timeout": { ... }
}
```

References: [Menus API](https://github.com/2600hz/kazoo/blob/master/applications/crossbar/doc/menus.md)