### PR TITLE
MSPB-395: Fix holiday cross-account data leakage

### DIFF
--- a/submodules/strategyHolidays/strategyHolidays.js
+++ b/submodules/strategyHolidays/strategyHolidays.js
@@ -871,8 +871,8 @@ define(function(require) {
 						}
 					}
 				}
-				self.appFlags.strategyHolidays.allHolidays = holidaysData;
 			});
+			self.appFlags.strategyHolidays.allHolidays = holidaysData;
 			self.appFlags.strategyHolidays.deletedHolidays = [];
 
 			return holidaysData;


### PR DESCRIPTION
Fix client-side caching bug where holiday settings from one account appear in another account when viewing Smart PBX > Main # > Office Holidays.

### Changes

- Move `appFlags.strategyHolidays.allHolidays` assignment outside forEach loop to ensure cache is always reset on account switch

### Test Plan

- [x] Account A (with holidays) > Account B (no holidays): B shows empty list
- [x] Account B > Account A: A shows its holidays correctly
- [x] Create holiday in Account B after viewing A: holiday created in B only
- [x] Edit/delete holiday after account switch: correct holiday modified
- [x] Import CSV after account switch: holidays imported to correct account