### PR TITLE
[5.4] MSPB-395: (fix) holiday cross-account data leakage

### DIFF
--- a/submodules/strategyHolidays/strategyHolidays.js
+++ b/submodules/strategyHolidays/strategyHolidays.js
@@ -871,8 +871,8 @@ define(function(require) {
 						}
 					}
 				}
-				self.appFlags.strategyHolidays.allHolidays = holidaysData;
 			});
+			self.appFlags.strategyHolidays.allHolidays = holidaysData;
 			self.appFlags.strategyHolidays.deletedHolidays = [];
 
 			return holidaysData;


### PR DESCRIPTION
Move cache assignment outside forEach loop to ensure appFlags.allHolidays is always reset when switching accounts, even when the new account has no holidays configured.