### PR TITLE
[5.5] MSPB-405: Fix e911 display duplication in Company Caller ID

### DIFF
--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -912,7 +912,11 @@ define(function(require) {
 
 							if (hasE911 && isE911Enabled) {
 								if (_.has(numberData, 'e911')) {
-									var street_address = _.get(numberData, 'e911.legacy_data.house_number', '') + ' ' + _.get(numberData, 'e911.street_address', '');
+									var streetAddress = _.get(numberData, 'e911.street_address', ''),
+										houseNumber = _.get(numberData, 'e911.legacy_data.house_number', ''),
+										street_address = _.isEmpty(houseNumber) || _.startsWith(streetAddress, houseNumber)
+											? streetAddress
+											: _.trim([houseNumber, streetAddress].join(' '));
 
 									emergencyZipcodeInput.val(numberData.e911.postal_code);
 									emergencyAddress1Input.val(street_address);


### PR DESCRIPTION
## Summary
- Fix duplicated house number display in Company Caller ID by `adding _.startsWith` guard
- Display-only fix, save logic unchanged (save cleanup deferred to [MSPB-397](https://github.com/2600hz/monster-ui-voip/pull/590) + [KINT-2](https://oomacorp.atlassian.net/browse/KINT-2))

## Context
Splitting from [MSPB-397](https://github.com/2600hz/monster-ui-voip/pull/590) to ship the display fix independently. [MSPB-397](https://github.com/2600hz/monster-ui-voip/pull/590) includes save logic changes that depend on [KINT-2](https://oomacorp.atlassian.net/browse/KINT-2) (backend owning legacy_data decomposition). This PR addresses  the user-facing bug from `SUPP-977` without waiting on backend changes.

## Changes
- `submodules/myOffice/myOffice.js` - display guard to prevent prepending `house_number` when 
  street_address already contains it

## Test Plan
- [ ] Verify Company Caller ID displays `street_address` without duplication for all address formats (Dash, Intrado, historical)
- [x] Verify save behaviour is unchanged

## Ticket
MSPB-405: Company Caller ID duplicates E911 house number (display fix)
https://oomacorp.atlassian.net/browse/MSPB-405
