### PR TITLE
[5.3] MSPB-405: Fix e911 display duplication in Company Caller ID

### DIFF
--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -912,7 +912,11 @@ define(function(require) {
 
 							if (hasE911 && isE911Enabled) {
 								if (_.has(numberData, 'e911')) {
-									var street_address = _.get(numberData, 'e911.legacy_data.house_number', '') + ' ' + _.get(numberData, 'e911.street_address', '');
+									var streetAddress = _.get(numberData, 'e911.street_address', ''),
+										houseNumber = _.get(numberData, 'e911.legacy_data.house_number', ''),
+										street_address = _.isEmpty(houseNumber) || _.startsWith(streetAddress, houseNumber)
+											? streetAddress
+											: _.trim([houseNumber, streetAddress].join(' '));
 
 									emergencyZipcodeInput.val(numberData.e911.postal_code);
 									emergencyAddress1Input.val(street_address);


### PR DESCRIPTION
## Summary
- Cherry-pick `MSPB-405` onto `fix-5.3.14` to produce service pack `5.3.14.2`
- Same display-only fix as the `5.3` backport (#597) and the master PR (#593)
- Targets `meta-kazoo-5.3.121` `LTS` (per ticket policy)

## Source
Cherry-picked from `d6aeb73` on `origin/5.3` (the squash-merge commit of #597). Author amended to rromana@2600hz.com to drop the GH noreply mask.

## Changes
- `submodules/myOffice/myOffice.js` - display guard, 5 insertions / 1 deletion (identical to `5.4.15.1` SP and the original `5.3` backport)

## Test plan
- [x] CI `build_branch` green
- [ ] After merge: tag `5.3.14.2` from this commit, push tag, monitor shipyard lifecycle

## Ticket
`MSPB-405`: Company Caller ID duplicates E911 house number (display fix)
https://oomacorp.atlassian.net/browse/MSPB-405

## Related
- `Master`: #593
- `5.3` backport: #597 (merged)
- `5.4` backport: #594 (merged)
- `5.5` backport: #595 (merged)
- `5.4` SP shipped: `5.4.15.1`