### PR TITLE
[5.4] MSPB-397: Fix e911 save logic in myOffice

### DIFF
--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -1027,8 +1027,6 @@ define(function(require) {
 							}
 
 							if (setE911) {
-								var splitAddress = e911Data.street_address.split(/\s/g);
-
 								_.assign(numberData, {
 									e911: _.assign({}, e911Data, {
 										notification_contact_emails: _
@@ -1041,10 +1039,7 @@ define(function(require) {
 											.uniq()
 											.value(),
 										caller_name: monster.apps.auth.currentAccount.name,
-										legacy_data: {
-											house_number: _.head(splitAddress)
-										},
-										street_address: splitAddress.slice(1).join(' ')
+										street_address: _.trim(e911Data.street_address)
 									})
 								});
 							} else {


### PR DESCRIPTION
## Summary
- Stop constructing `legacy_data` client-side on save, send complete `street_address` as-is
- Display fix moved to [MSPB-405](https://github.com/2600hz/monster-ui-voip/pull/593)

## Changes
- `submodules/myOffice/myOffice.js` - save logic cleanup

## Test Plan
- [ ] Verify saving E911 via Company Caller ID sends complete `street_address`
- [ ] Confirm [KINT-2](https://oomacorp.atlassian.net/browse/KINT-2) is done/merged before testing save behaviour, as backend now owns `legacy_data` decomposition

## Ticket
MSPB-397: Company Caller ID duplicates E911 house number
https://oomacorp.atlassian.net/browse/MSPB-397

