### PR TITLE
MSPB-406: Add Canada country support to Company Caller ID e911 form

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1315,6 +1315,24 @@
 				"us": {
 					"value": "US",
 					"option": "United States"
+				},
+				"ca": {
+					"value": "CA",
+					"option": "Canada"
+				}
+			},
+			"labels": {
+				"us": {
+					"postalCode": "Zip Code",
+					"region": "State",
+					"postalPlaceholder": "12345",
+					"regionPlaceholder": "CA"
+				},
+				"ca": {
+					"postalCode": "Postal Code",
+					"region": "Province",
+					"postalPlaceholder": "A1A 1A1",
+					"regionPlaceholder": "ON"
 				}
 			}
 		},

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1300,11 +1300,11 @@
 			"nameLabel": "Company Caller ID name",
 			"nameHelp": "This name will appear as your Caller ID when you make outbound calls.",
 			"emergencyLabel": "Company Emergency (E911) Information",
-			"emergencyZipcode": "Zip Code",
+			"emergencyZipcode": "Zip/Postal Code",
 			"emergencyAddress1": "Address Line 1",
-			"emergencyAddress2": "Address Line 2",
+			"emergencyAddress2": "Extended Address",
 			"emergencyCity": "City",
-			"emergencyState": "State",
+			"emergencyState": "State/Province",
 			"emergencyEmail": "Email Address(es)",
 			"emergencyCountry": "Country",
 			"emergencyEmailError": "Invalid space separated address(es)",
@@ -1316,7 +1316,7 @@
 					"value": "US",
 					"option": "United States"
 				},
-				"ca": {
+				"canada": {
 					"value": "CA",
 					"option": "Canada"
 				}

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1321,18 +1321,14 @@
 					"option": "Canada"
 				}
 			},
-			"labels": {
+			"placeholders": {
 				"us": {
-					"postalCode": "Zip Code",
-					"region": "State",
-					"postalPlaceholder": "12345",
-					"regionPlaceholder": "CA"
+					"postalCode": "12345",
+					"region": "CA"
 				},
 				"ca": {
-					"postalCode": "Postal Code",
-					"region": "Province",
-					"postalPlaceholder": "A1A 1A1",
-					"regionPlaceholder": "ON"
+					"postalCode": "A1A 1A1",
+					"region": "ON"
 				}
 			}
 		},

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1306,7 +1306,7 @@
 			"emergencyCity": "City",
 			"emergencyState": {
 				"label": "State",
-				"placeholder": "2-letter code"
+				"placeholder": "2 Letter Code"
 			},
 			"emergencyEmail": "Email Address(es)",
 			"emergencyCountry": "Country",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1300,11 +1300,14 @@
 			"nameLabel": "Company Caller ID name",
 			"nameHelp": "This name will appear as your Caller ID when you make outbound calls.",
 			"emergencyLabel": "Company Emergency (E911) Information",
-			"emergencyZipcode": "Zip/Postal Code",
-			"emergencyAddress1": "Address Line 1",
+			"emergencyZipcode": "Zip Code",
+			"emergencyAddress1": "Address",
 			"emergencyAddress2": "Extended Address",
 			"emergencyCity": "City",
-			"emergencyState": "State/Province",
+			"emergencyState": {
+				"label": "State",
+				"placeholder": "2-letter code"
+			},
 			"emergencyEmail": "Email Address(es)",
 			"emergencyCountry": "Country",
 			"emergencyEmailError": "Invalid space separated address(es)",
@@ -1314,21 +1317,21 @@
 			"countries": {
 				"us": {
 					"value": "US",
-					"option": "United States"
-				},
-				"canada": {
-					"value": "CA",
-					"option": "Canada"
-				}
-			},
-			"placeholders": {
-				"us": {
-					"postalCode": "12345",
-					"region": "CA"
+					"option": "United States",
+					"postalCode": {
+						"label": "Zip Code",
+						"placeholder": "12345"
+					},
+					"region": "State"
 				},
 				"ca": {
-					"postalCode": "A1A 1A1",
-					"region": "ON"
+					"value": "CA",
+					"option": "Canada",
+					"postalCode": {
+						"label": "Postal Code",
+						"placeholder": "A1A 1A1"
+					},
+					"region": "Province"
 				}
 			}
 		},

--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -855,6 +855,12 @@ define(function(require) {
 				});
 
 				monster.ui.valid(e911Form);
+
+				self.myOfficeApplyCountryUi(e911Form, 'US');
+
+				e911Form.find('select[name="country"]').on('change', function() {
+					self.myOfficeApplyCountryUi(e911Form, $(this).val());
+				});
 			}
 
 			self.myOfficeCallerIdPopupBindEvents({
@@ -929,6 +935,10 @@ define(function(require) {
 										.join(' ')
 										.value()
 									);
+
+									var savedCountry = numberData.e911.country || 'US';
+									popupTemplate.find('select[name="country"]').val(savedCountry);
+									self.myOfficeApplyCountryUi(popupTemplate, savedCountry);
 								} else {
 									emergencyZipcodeInput.val('');
 									emergencyAddress1Input.val('');
@@ -936,6 +946,9 @@ define(function(require) {
 									emergencyCityInput.val('');
 									emergencyStateInput.val('');
 									emergencyEmailInput.val('');
+
+									popupTemplate.find('select[name="country"]').val('US');
+									self.myOfficeApplyCountryUi(popupTemplate, 'US');
 								}
 							}
 
@@ -1077,6 +1090,22 @@ define(function(require) {
 			});
 
 			loadNumberDetails(callerIdNumberSelect.val(), popupTemplate);
+		},
+
+		myOfficeApplyCountryUi: function(form, country) {
+			var self = this,
+				key = (country || 'US').toLowerCase(),
+				i18nLabels = _.get(self.i18n.active(), 'myOffice.callerId.labels', {}),
+				labels = i18nLabels[key] || i18nLabels.us;
+
+			if (!labels) {
+				return;
+			}
+
+			form.find('input[name="postal_code"]').closest('label').find('.emergency-form-label').text(labels.postalCode);
+			form.find('input[name="postal_code"]').attr('placeholder', labels.postalPlaceholder);
+			form.find('input[name="region"]').closest('label').find('.emergency-form-label').text(labels.region);
+			form.find('input[name="region"]').attr('placeholder', labels.regionPlaceholder);
 		},
 
 		myOfficeWalkthroughRender: function() {

--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -833,6 +833,11 @@ define(function(require) {
 					rules: {
 						notification_contact_emails: {
 							listOf: 'email'
+						},
+						region: {
+							minlength: 2,
+							maxlength: 2,
+							lettersonly: true
 						}
 					},
 					messages: {

--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -835,9 +835,9 @@ define(function(require) {
 							listOf: 'email'
 						},
 						region: {
+							lettersonly: true,
 							minlength: 2,
-							maxlength: 2,
-							lettersonly: true
+							maxlength: 2
 						}
 					},
 					messages: {

--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -856,6 +856,30 @@ define(function(require) {
 						notification_contact_emails: {
 							regex: self.i18n.active().myOffice.callerId.emergencyEmailError
 						}
+					},
+					errorPlacement: function(error, element) {
+						var container = element.closest('.horizontal-error-container');
+						if (container.length && error.text() !== '*') {
+							container.append(error);
+						} else if (container.length) {
+							error.insertAfter(container);
+						} else {
+							error.insertAfter(element);
+						}
+					},
+					showErrors: function(errorMap, errorList) {
+						this.defaultShowErrors();
+						$.each(errorList, function(_, e) {
+							var $el = $(e.element);
+							var $lbl = $('#' + $el.attr('name') + '-error');
+							var $container = $el.closest('.horizontal-error-container');
+							if (!$container.length || !$lbl.length) return;
+							if ($lbl.text() === '*') {
+								$container.after($lbl);
+							} else {
+								$container.append($lbl);
+							}
+						});
 					}
 				});
 

--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -1124,15 +1124,16 @@ define(function(require) {
 		myOfficeApplyCountryUi: function(form, country) {
 			var self = this,
 				key = (country || 'US').toLowerCase(),
-				i18nPlaceholders = _.get(self.i18n.active(), 'myOffice.callerId.placeholders', {}),
-				hints = i18nPlaceholders[key] || i18nPlaceholders.us;
+				i18nCountries = _.get(self.i18n.active(), 'myOffice.callerId.countries', {}),
+				countryLabels = i18nCountries[key] || i18nCountries.us;
 
-			if (!hints) {
+			if (!countryLabels) {
 				return;
 			}
 
-			form.find('input[name="postal_code"]').attr('placeholder', hints.postalCode);
-			form.find('input[name="region"]').attr('placeholder', hints.region);
+			form.find('input[name="postal_code"]').closest('label').find('.emergency-form-label').text(_.get(countryLabels, 'postalCode.label'));
+			form.find('input[name="postal_code"]').attr('placeholder', _.get(countryLabels, 'postalCode.placeholder'));
+			form.find('input[name="region"]').closest('label').find('.emergency-form-label').text(_.get(countryLabels, 'region'));
 		},
 
 		myOfficeWalkthroughRender: function() {

--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -1100,17 +1100,15 @@ define(function(require) {
 		myOfficeApplyCountryUi: function(form, country) {
 			var self = this,
 				key = (country || 'US').toLowerCase(),
-				i18nLabels = _.get(self.i18n.active(), 'myOffice.callerId.labels', {}),
-				labels = i18nLabels[key] || i18nLabels.us;
+				i18nPlaceholders = _.get(self.i18n.active(), 'myOffice.callerId.placeholders', {}),
+				hints = i18nPlaceholders[key] || i18nPlaceholders.us;
 
-			if (!labels) {
+			if (!hints) {
 				return;
 			}
 
-			form.find('input[name="postal_code"]').closest('label').find('.emergency-form-label').text(labels.postalCode);
-			form.find('input[name="postal_code"]').attr('placeholder', labels.postalPlaceholder);
-			form.find('input[name="region"]').closest('label').find('.emergency-form-label').text(labels.region);
-			form.find('input[name="region"]').attr('placeholder', labels.regionPlaceholder);
+			form.find('input[name="postal_code"]').attr('placeholder', hints.postalCode);
+			form.find('input[name="region"]').attr('placeholder', hints.region);
 		},
 
 		myOfficeWalkthroughRender: function() {

--- a/submodules/myOffice/partials/_callerIdPopup.scss
+++ b/submodules/myOffice/partials/_callerIdPopup.scss
@@ -33,6 +33,12 @@
 
 				.horizontal-error-container {
 					position: relative;
+					margin-bottom: 10px;
+
+					input,
+					textarea {
+						margin-bottom: 0;
+					}
 				}
 			}
 			textarea {
@@ -42,12 +48,14 @@
 				position: relative;
 				margin-left: 5px;
 				font-size: 30px;
-
-				&#notification_contact_emails-error {
-					position: absolute;
-					margin: -10px 0 0 10px;
-					font-size: 12px;
-				}
+			}
+			.horizontal-error-container > label.monster-invalid {
+				margin: 2px 0 0 10px;
+				font-size: 12px;
+				display: block;
+				max-width: 220px;
+				white-space: normal;
+				word-wrap: break-word;
 			}
 		}
 	}

--- a/submodules/myOffice/views/callerIdPopup.html
+++ b/submodules/myOffice/views/callerIdPopup.html
@@ -61,8 +61,11 @@
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyCountry }}</span>
 					<select class="country-list" name="country">
-						<option value="{{ i18n.myOffice.callerId.countries.us.value }}" selected>
+						<option value="{{ i18n.myOffice.callerId.countries.us.value }}">
 							{{ i18n.myOffice.callerId.countries.us.option }}
+						</option>
+						<option value="{{ i18n.myOffice.callerId.countries.ca.value }}">
+							{{ i18n.myOffice.callerId.countries.ca.option }}
 						</option>
 					</select>
 				</label>

--- a/submodules/myOffice/views/callerIdPopup.html
+++ b/submodules/myOffice/views/callerIdPopup.html
@@ -50,7 +50,9 @@
 				</label>
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyState }}</span>
-					<input required name="region" type="text" class="caller-id-emergency-state">
+					<div class="horizontal-error-container">
+						<input required name="region" type="text" class="caller-id-emergency-state">
+					</div>
 				</label>
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyEmail }}</span>
@@ -61,12 +63,14 @@
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyCountry }}</span>
 					<select class="country-list" name="country">
-						<option value="{{ i18n.myOffice.callerId.countries.us.value }}">
+						{{#select country}}
+						<option value="{{ i18n.myOffice.callerId.countries.canada.value }}">
+							{{ i18n.myOffice.callerId.countries.canada.option }}
+						</option>
+						<option value="{{ i18n.myOffice.callerId.countries.us.value }}" selected>
 							{{ i18n.myOffice.callerId.countries.us.option }}
 						</option>
-						<option value="{{ i18n.myOffice.callerId.countries.ca.value }}">
-							{{ i18n.myOffice.callerId.countries.ca.option }}
-						</option>
+						{{/select}}
 					</select>
 				</label>
 			</form>

--- a/submodules/myOffice/views/callerIdPopup.html
+++ b/submodules/myOffice/views/callerIdPopup.html
@@ -33,8 +33,17 @@
 
 			<form id="emergency_form">
 				<label>
-					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyZipcode }}</span>
-					<input required name="postal_code" type="text" class="caller-id-emergency-zipcode" placeholder="{{ i18n.myOffice.callerId.placeholders.us.postalCode }}">
+					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyCountry }}</span>
+					<select class="country-list" name="country">
+						{{#select country}}
+						<option value="{{ i18n.myOffice.callerId.countries.us.value }}">
+							{{ i18n.myOffice.callerId.countries.us.option }}
+						</option>
+						<option value="{{ i18n.myOffice.callerId.countries.ca.value }}">
+							{{ i18n.myOffice.callerId.countries.ca.option }}
+						</option>
+						{{/select}}
+					</select>
 				</label>
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyAddress1 }}</span>
@@ -49,29 +58,20 @@
 					<input required name="locality" type="text" class="caller-id-emergency-city" placeholder="{{ i18n.myOffice.callerId.emergencyCity }}">
 				</label>
 				<label>
-					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyState }}</span>
+					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyState.label }}</span>
 					<div class="horizontal-error-container">
-						<input required name="region" type="text" class="caller-id-emergency-state" placeholder="{{ i18n.myOffice.callerId.placeholders.us.region }}">
+						<input required name="region" type="text" class="caller-id-emergency-state" placeholder="{{ i18n.myOffice.callerId.emergencyState.placeholder }}">
 					</div>
+				</label>
+				<label>
+					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyZipcode }}</span>
+					<input required name="postal_code" type="text" class="caller-id-emergency-zipcode" placeholder="{{ i18n.myOffice.callerId.countries.us.postalCode.placeholder }}">
 				</label>
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyEmail }}</span>
 					<div class="horizontal-error-container">
 						<textarea name="notification_contact_emails" class="caller-id-emergency-email"></textarea>
 					</div>
-				</label>
-				<label>
-					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyCountry }}</span>
-					<select class="country-list" name="country">
-						{{#select country}}
-						<option value="{{ i18n.myOffice.callerId.countries.canada.value }}">
-							{{ i18n.myOffice.callerId.countries.canada.option }}
-						</option>
-						<option value="{{ i18n.myOffice.callerId.countries.us.value }}" selected>
-							{{ i18n.myOffice.callerId.countries.us.option }}
-						</option>
-						{{/select}}
-					</select>
 				</label>
 			</form>
 

--- a/submodules/myOffice/views/callerIdPopup.html
+++ b/submodules/myOffice/views/callerIdPopup.html
@@ -34,24 +34,24 @@
 			<form id="emergency_form">
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyZipcode }}</span>
-					<input required name="postal_code" type="text" class="caller-id-emergency-zipcode">
+					<input required name="postal_code" type="text" class="caller-id-emergency-zipcode" placeholder="{{ i18n.myOffice.callerId.placeholders.us.postalCode }}">
 				</label>
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyAddress1 }}</span>
-					<input required name="street_address" type="text" class="caller-id-emergency-address1">
+					<input required name="street_address" type="text" class="caller-id-emergency-address1" placeholder="{{ i18n.myOffice.callerId.emergencyAddress1 }}">
 				</label>
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyAddress2 }}</span>
-					<input name="extended_address" type="text" class="caller-id-emergency-address2">
+					<input name="extended_address" type="text" class="caller-id-emergency-address2" placeholder="{{ i18n.myOffice.callerId.emergencyAddress2 }}">
 				</label>
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyCity }}</span>
-					<input required name="locality" type="text" class="caller-id-emergency-city">
+					<input required name="locality" type="text" class="caller-id-emergency-city" placeholder="{{ i18n.myOffice.callerId.emergencyCity }}">
 				</label>
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyState }}</span>
 					<div class="horizontal-error-container">
-						<input required name="region" type="text" class="caller-id-emergency-state">
+						<input required name="region" type="text" class="caller-id-emergency-state" placeholder="{{ i18n.myOffice.callerId.placeholders.us.region }}">
 					</div>
 				</label>
 				<label>

--- a/submodules/myOffice/views/callerIdPopup.html
+++ b/submodules/myOffice/views/callerIdPopup.html
@@ -60,7 +60,7 @@
 				<label>
 					<span class="emergency-form-label">{{ i18n.myOffice.callerId.emergencyState.label }}</span>
 					<div class="horizontal-error-container">
-						<input required name="region" type="text" class="caller-id-emergency-state" placeholder="{{ i18n.myOffice.callerId.emergencyState.placeholder }}">
+						<input required name="region" type="text" maxlength="2" class="caller-id-emergency-state" placeholder="{{ i18n.myOffice.callerId.emergencyState.placeholder }}">
 					</div>
 				</label>
 				<label>


### PR DESCRIPTION
Adds Canada to the country selector in the SmartPBX Company Caller ID `e911` emergency address form (`myOffice` submodule). Labels and placeholders react to the selected country.

## Note

Backend wiring for Canadian addresses lives on [KINT-3](https://oomacorp.atlassian.net/browse/KINT-3) (`kazoo-intrado` integration).

## Ticket

[MSPB-406](https://oomacorp.atlassian.net/browse/MSPB-406), sibling [MSTR-352](https://oomacorp.atlassian.net/browse/MSTR-352)
