### PR TITLE
[5.4] MSPB-405: Fix e911 display duplication in Company Caller ID

### DIFF
--- a/submodules/myOffice/myOffice.js
+++ b/submodules/myOffice/myOffice.js
@@ -912,7 +912,11 @@ define(function(require) {
 
 							if (hasE911 && isE911Enabled) {
 								if (_.has(numberData, 'e911')) {
-									var street_address = _.get(numberData, 'e911.legacy_data.house_number', '') + ' ' + _.get(numberData, 'e911.street_address', '');
+									var streetAddress = _.get(numberData, 'e911.street_address', ''),
+										houseNumber = _.get(numberData, 'e911.legacy_data.house_number', ''),
+										street_address = _.isEmpty(houseNumber) || _.startsWith(streetAddress, houseNumber)
+											? streetAddress
+											: _.trim([houseNumber, streetAddress].join(' '));
 
 									emergencyZipcodeInput.val(numberData.e911.postal_code);
 									emergencyAddress1Input.val(street_address);


### PR DESCRIPTION
## Ticket
`MSPB-405`: Company Caller ID duplicates E911 house number (display fix)
https://oomacorp.atlassian.net/browse/MSPB-405

## Related
- `Master`: #593
- `5.3` backport: #597 (merged)
- `5.4` backport: #594 (merged)
- `5.5` backport: #595 (merged)
- `5.3` SP shipped: `5.3.14.2` (via #600)
- `5.4` SP shipped: `5.4.15.1`, `5.4.16.1`